### PR TITLE
Use SIMD on amd64 and VSX on ppc64x for XOR

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,8 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sasl
+
+// Export internal functions for testing.
+var XorBytes = xorBytes

--- a/xor_amd64.go
+++ b/xor_amd64.go
@@ -1,8 +1,8 @@
-// Copyright 2013 The Go Authors. All rights reserved.
+// Copyright 2018 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !386,!amd64,!ppc64,!ppc64le,!s390x,!appengine
+// +build amd64
 
 package sasl
 
@@ -16,17 +16,14 @@ func xorBytes(dst, a, b []byte) int {
 	if n == 0 {
 		return 0
 	}
-
-	for i := 0; i < n; i++ {
-		dst[i] = a[i] ^ b[i]
-	}
+	_ = dst[n-1]
+	xorBytesSSE2(&dst[0], &a[0], &b[0], n) // amd64 must have SSE2
 	return n
 }
 
-// fastXORWords XORs multiples of 4 or 8 bytes (depending on architecture.)
-// The slice arguments a and b are assumed to be of equal length.
 func xorWords(dst, a, b []byte) {
-	for i := 0; i < len(b); i++ {
-		dst[i] = a[i] ^ b[i]
-	}
+	xorBytes(dst, a, b)
 }
+
+//go:noescape
+func xorBytesSSE2(dst, a, b *byte, n int)

--- a/xor_amd64.s
+++ b/xor_amd64.s
@@ -1,0 +1,54 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+// func xorBytesSSE2(dst, a, b *byte, n int)
+TEXT ·xorBytesSSE2(SB), NOSPLIT, $0
+	MOVQ  dst+0(FP), BX
+	MOVQ  a+8(FP), SI
+	MOVQ  b+16(FP), CX
+	MOVQ  n+24(FP), DX
+	TESTQ $15, DX            // AND 15 & len, if not zero jump to not_aligned.
+	JNZ   not_aligned
+
+aligned:
+	MOVQ $0, AX // position in slices
+
+loop16b:
+	MOVOU (SI)(AX*1), X0   // XOR 16byte forwards.
+	MOVOU (CX)(AX*1), X1
+	PXOR  X1, X0
+	MOVOU X0, (BX)(AX*1)
+	ADDQ  $16, AX
+	CMPQ  DX, AX
+	JNE   loop16b
+	RET
+
+loop_1b:
+	SUBQ  $1, DX           // XOR 1byte backwards.
+	MOVB  (SI)(DX*1), DI
+	MOVB  (CX)(DX*1), AX
+	XORB  AX, DI
+	MOVB  DI, (BX)(DX*1)
+	TESTQ $7, DX           // AND 7 & len, if not zero jump to loop_1b.
+	JNZ   loop_1b
+	CMPQ  DX, $0           // if len is 0, ret.
+	JE    ret
+	TESTQ $15, DX          // AND 15 & len, if zero jump to aligned.
+	JZ    aligned
+
+not_aligned:
+	TESTQ $7, DX           // AND $7 & len, if not zero jump to loop_1b.
+	JNE   loop_1b
+	SUBQ  $8, DX           // XOR 8bytes backwards.
+	MOVQ  (SI)(DX*1), DI
+	MOVQ  (CX)(DX*1), AX
+	XORQ  AX, DI
+	MOVQ  DI, (BX)(DX*1)
+	CMPQ  DX, $16          // if len is greater or equal 16 here, it must be aligned.
+	JGE   aligned
+
+ret:
+	RET

--- a/xor_ppc64x.go
+++ b/xor_ppc64x.go
@@ -1,0 +1,29 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build ppc64 ppc64le
+
+package cipher
+
+// xorBytes xors the bytes in a and b. The destination should have enough
+// space, otherwise xorBytes will panic. Returns the number of bytes xor'd.
+func xorBytes(dst, a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	if n == 0 {
+		return 0
+	}
+	_ = dst[n-1]
+	xorBytesVSX(&dst[0], &a[0], &b[0], n)
+	return n
+}
+
+func xorWords(dst, a, b []byte) {
+	xorBytes(dst, a, b)
+}
+
+//go:noescape
+func xorBytesVSX(dst, a, b *byte, n int)

--- a/xor_ppc64x.s
+++ b/xor_ppc64x.s
@@ -1,0 +1,66 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build ppc64 ppc64le
+
+#include "textflag.h"
+
+// func xorBytesVSX(dst, a, b *byte, n int)
+TEXT ·xorBytesVSX(SB), NOSPLIT, $0
+	MOVD	dst+0(FP), R3	// R3 = dst
+	MOVD	a+8(FP), R4	// R4 = a
+	MOVD	b+16(FP), R5	// R5 = b
+	MOVD	n+24(FP), R6	// R6 = n
+
+	CMPU	R6, $16, CR7	// Check if n ≥ 16 bytes
+	MOVD	R0, R8		// R8 = index
+	CMPU	R6, $8, CR6	// Check if 8 ≤ n < 16 bytes
+	BGE	CR7, preloop16
+	BLT	CR6, small
+
+	// Case for 8 ≤ n < 16 bytes
+	MOVD	(R4)(R8), R14	// R14 = a[i,...,i+7]
+	MOVD	(R5)(R8), R15	// R15 = b[i,...,i+7]
+	XOR	R14, R15, R16	// R16 = a[] ^ b[]
+	SUB	$8, R6		// n = n - 8
+	MOVD	R16, (R3)(R8)	// Store to dst
+	ADD	$8, R8
+
+	// Check if we're finished
+	CMP	R6, R0
+	BGT	small
+	JMP	done
+
+	// Case for n ≥ 16 bytes
+preloop16:
+	SRD	$4, R6, R7	// Setup loop counter
+	MOVD	R7, CTR
+	ANDCC	$15, R6, R9	// Check for tailing bytes for later
+loop16:
+	LXVD2X		(R4)(R8), VS32		// VS32 = a[i,...,i+15]
+	LXVD2X		(R5)(R8), VS33		// VS33 = b[i,...,i+15]
+	XXLXOR		VS32, VS33, VS34	// VS34 = a[] ^ b[]
+	STXVD2X		VS34, (R3)(R8)		// Store to dst
+	ADD		$16, R8			// Update index
+	BC		16, 0, loop16		// bdnz loop16
+
+	BEQ		CR0, done
+	SLD		$4, R7
+	SUB		R7, R6			// R6 = n - (R7 * 16)
+
+	// Case for n < 8 bytes and tailing bytes from the
+	// previous cases.
+small:
+	MOVD	R6, CTR		// Setup loop counter
+
+loop:
+	MOVBZ	(R4)(R8), R14	// R14 = a[i]
+	MOVBZ	(R5)(R8), R15	// R15 = b[i]
+	XOR	R14, R15, R16	// R16 = a[i] ^ b[i]
+	MOVB	R16, (R3)(R8)	// Store to dst
+	ADD	$1, R8
+	BC	16, 0, loop	// bdnz loop
+
+done:
+	RET

--- a/xor_test.go
+++ b/xor_test.go
@@ -1,0 +1,73 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sasl_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"testing"
+
+	"mellium.im/sasl"
+)
+
+func TestXOR(t *testing.T) {
+	for j := 1; j <= 1024; j++ {
+		for alignP := 0; alignP < 2; alignP++ {
+			for alignQ := 0; alignQ < 2; alignQ++ {
+				for alignD := 0; alignD < 2; alignD++ {
+					p := make([]byte, j)[alignP:]
+					q := make([]byte, j)[alignQ:]
+					d1 := make([]byte, j+alignD)[alignD:]
+					d2 := make([]byte, j+alignD)[alignD:]
+					if _, err := io.ReadFull(rand.Reader, p); err != nil {
+						t.Fatal(err)
+					}
+					if _, err := io.ReadFull(rand.Reader, q); err != nil {
+						t.Fatal(err)
+					}
+					sasl.XorBytes(d1, p, q)
+					n := min(p, q)
+					for i := 0; i < n; i++ {
+						d2[i] = p[i] ^ q[i]
+					}
+					if !bytes.Equal(d1, d2) {
+						t.Logf("p: %#v", p)
+						t.Logf("q: %#v", q)
+						t.Logf("expect: %#v", d2)
+						t.Logf("result: %#v", d1)
+						t.Fatal("not equal")
+					}
+				}
+			}
+		}
+	}
+}
+
+func min(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	return n
+}
+
+func BenchmarkXORBytes(b *testing.B) {
+	dst := make([]byte, 1<<15)
+	data0 := make([]byte, 1<<15)
+	data1 := make([]byte, 1<<15)
+	sizes := []int64{1 << 3, 1 << 7, 1 << 11, 1 << 15}
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("%dBytes", size), func(b *testing.B) {
+			s0 := data0[:size]
+			s1 := data1[:size]
+			b.SetBytes(int64(size))
+			for i := 0; i < b.N; i++ {
+				sasl.XorBytes(dst, s0, s1)
+			}
+		})
+	}
+}

--- a/xor_unaligned.go
+++ b/xor_unaligned.go
@@ -4,7 +4,7 @@
 
 // This file was split out from Go's crypto/cipher/xor.go
 
-// +build 386 amd64 ppc64 ppc64le s390x appengine
+// +build 386 ppc64 ppc64le s390x appengine
 
 package sasl
 

--- a/xor_unaligned.go
+++ b/xor_unaligned.go
@@ -4,7 +4,7 @@
 
 // This file was split out from Go's crypto/cipher/xor.go
 
-// +build 386 ppc64 ppc64le s390x appengine
+// +build 386 s390x appengine
 
 package sasl
 


### PR DESCRIPTION
Borrowed from https://golang.org/cl/125316 and https://golang.org/cl/145997