### PR TITLE
remove duplicated switch case

### DIFF
--- a/scram.go
+++ b/scram.go
@@ -142,9 +142,6 @@ func scramClientNext(name string, fn func() hash.Hash, m *Negotiator, challenge 
 
 		switch {
 		case iter < 0:
-			err = errors.New("Iteration count is missing")
-			return
-		case iter < 0:
 			err = errors.New("Iteration count is invalid")
 			return
 		case nonce == nil || !bytes.HasPrefix(nonce, m.Nonce()):


### PR DESCRIPTION
There were 2 `iter < 0` cases.
This means that only first case will ever be executed while
the other one is effectively a dead code.