### PR TITLE
Fix xor build tags

### DIFF
--- a/xor_generic.go
+++ b/xor_generic.go
@@ -4,7 +4,7 @@
 
 // This file was split out from Go's crypto/cipher/xor.go
 
-// +build !386,!amd64,!ppc64,!ppc64le,!s390x,!appengine
+// +build !386,!amd64,!ppc64,!ppc64le,!s390x appengine
 
 package sasl
 

--- a/xor_unaligned.go
+++ b/xor_unaligned.go
@@ -4,7 +4,8 @@
 
 // This file was split out from Go's crypto/cipher/xor.go
 
-// +build 386 amd64 ppc64 ppc64le s390x appengine
+// +build 386 amd64 ppc64 ppc64le s390x
+// +build !appendine
 
 package sasl
 


### PR DESCRIPTION
Fixes https://github.com/go-pg/pg/issues/1144

As I understand
- `+build !386,!amd64,!ppc64,!ppc64le,!s390x appengine` - means `(NOT 386 AND NOT amd64 AND NOT ppc64 AND NOT ppc64le AND NOT s390x) or appengine`
- `+build 386 amd64 ppc64 ppc64le s390x +build !appendine` - means `(386 OR amd64 OR ppc64 OR ppc64le OR s390x) AND NOT appengine`

appengine is excluded because it does not allow `unsafe`