### PR TITLE
sasl: error if CB is used without tls-unique data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+
+## Unreleased
+
+### Fixed
+
+- Return an error if no tls-unique channel binding (CB) data is present in the
+  TLS connection state (or no connection state exists) and we use SCRAM with CB.

--- a/sasl_test.go
+++ b/sasl_test.go
@@ -316,6 +316,68 @@ var saslTestCases = [...]saslTest{
 			{resp: []byte("Ursel\x00Kurt\x00xipj3plmq\x00"), serverErr: true, more: false},
 		},
 	},
+	16: {
+		skipServer: true,
+		mechanism:  scram("SCRAM-SHA-256-PLUS", sha256.New),
+		clientOpts: []Option{
+			RemoteMechanisms("SCRAM-SHA-256-PLUS"),
+			Credentials(func() ([]byte, []byte, []byte) {
+				return []byte("user"), []byte("pencil"), []byte("admin")
+			}),
+			TLSState(tls.ConnectionState{TLSUnique: []byte{}}),
+		},
+		steps: []saslStep{
+			{
+				resp: []byte("p=tls-unique,a=admin,n=user,r=fyko+d2lbbFgONRv9qkxdawL"),
+				more: true,
+			},
+			{
+				challenge: []byte(`r=fyko+d2lbbFgONRv9qkxdawL%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096`),
+				clientErr: true,
+			},
+		},
+	},
+	17: {
+		skipServer: true,
+		mechanism:  scram("SCRAM-SHA-256-PLUS", sha256.New),
+		clientOpts: []Option{
+			RemoteMechanisms("SCRAM-SHA-256-PLUS"),
+			Credentials(func() ([]byte, []byte, []byte) {
+				return []byte("user"), []byte("pencil"), []byte("admin")
+			}),
+			TLSState(tls.ConnectionState{TLSUnique: nil}),
+		},
+		steps: []saslStep{
+			{
+				resp: []byte("p=tls-unique,a=admin,n=user,r=fyko+d2lbbFgONRv9qkxdawL"),
+				more: true,
+			},
+			{
+				challenge: []byte(`r=fyko+d2lbbFgONRv9qkxdawL%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096`),
+				clientErr: true,
+			},
+		},
+	},
+	18: {
+		skipServer: true,
+		mechanism:  scram("SCRAM-SHA-256-PLUS", sha256.New),
+		clientOpts: []Option{
+			Credentials(func() ([]byte, []byte, []byte) {
+				return []byte("user"), []byte("pencil"), []byte("admin")
+			}),
+			RemoteMechanisms("SCRAM-SHA-256-PLUS"),
+		},
+		steps: []saslStep{
+			{
+				resp: []byte("n,a=admin,n=user,r=fyko+d2lbbFgONRv9qkxdawL"),
+				more: true,
+			},
+			{
+				challenge: []byte(`r=fyko+d2lbbFgONRv9qkxdawL%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096`),
+				clientErr: true,
+			},
+		},
+	},
 }
 
 func testClient(t *testing.T, client *Negotiator, tc saslTest, run int) {


### PR DESCRIPTION
An issue was discovered where the Prosody XMPP server would advertise
support for channel binding mechanisms in the SCRAM family even if TLS
1.3 was used (for which the tls-unique channel binding type is not
defined). This library would fail if no TLS connection state was
provided, but would hash in invalid channel binding data if a connection
state was provided but no TLS unique data existed.  If both the client
and server had a similar bug, it could possibly lead to a security issue
where authentication completes but the channel binding is not valid.

For more information see https://issues.prosody.im/1542 and
https://mellium.im/issue/46 (mellium/xmpp#46).

Signed-off-by: Sam Whited <sam@samwhited.com>